### PR TITLE
Correctly closes a gatt when a connection attempt is cancelled+

### DIFF
--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -97,7 +97,7 @@ namespace Plugin.BLE.Android
             {
                 var connectGatt = BluetoothDevice.ConnectGatt(Application.Context, connectParameters.AutoConnect, _gattCallback);
                 _connectCancellationTokenRegistration.Dispose();
-                _connectCancellationTokenRegistration = cancellationToken.Register(() => connectGatt.Disconnect());
+                _connectCancellationTokenRegistration = cancellationToken.Register(() => DisconnectAndClose(connectGatt));
             }
         }
 
@@ -110,7 +110,7 @@ namespace Plugin.BLE.Android
                 //no transport mode before lollipop, it will probably not work... gattCallBackError 133 again alas
                 var connectGatt = BluetoothDevice.ConnectGatt(Application.Context, autoconnect, _gattCallback);
                 _connectCancellationTokenRegistration.Dispose();
-                _connectCancellationTokenRegistration = cancellationToken.Register(() => connectGatt.Disconnect());
+                _connectCancellationTokenRegistration = cancellationToken.Register(() => DisconnectAndClose(connectGatt));
             }
             else if (Build.VERSION.SdkInt < BuildVersionCodes.M)
             {
@@ -127,9 +127,14 @@ namespace Plugin.BLE.Android
             {
                 var connectGatt = BluetoothDevice.ConnectGatt(Application.Context, autoconnect, _gattCallback, BluetoothTransports.Le);
                 _connectCancellationTokenRegistration.Dispose();
-                _connectCancellationTokenRegistration = cancellationToken.Register(() => connectGatt.Disconnect());
+                _connectCancellationTokenRegistration = cancellationToken.Register(() => DisconnectAndClose(connectGatt));
             }
+        }
 
+        private void DisconnectAndClose(BluetoothGatt gatt)
+        {
+            gatt.Disconnect();
+            gatt.Close();
         }
 
         /// <summary>


### PR DESCRIPTION
The gatt handles are leaking otherwise, resulting in too many open
handles. Android will block further attempts if an app has 32 open
gatts.